### PR TITLE
Add Goroutines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+launch.json
+go.sum

--- a/main.go
+++ b/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/kelvin-mai/go-port-scanner/port"
 )
 
 func main() {
+	start := time.Now()
 	port.GetOpenPorts("www.freecodecamp.com", port.PortRange{Start: 75, End: 85})
 
 	// called with ip address
@@ -18,4 +22,6 @@ func main() {
 
 	// verbose called with host name -- multiple ports returned
 	port.GetOpenPorts("scanme.nmap.org", port.PortRange{Start: 20, End: 80})
+	elapsed := time.Since(start)
+	fmt.Printf("Scan duration: %s", elapsed)
 }


### PR DESCRIPTION
I introduced Wait Groups, Channels and Goroutines to speed up the scan. The function *ScanPorts* is run in a Goroutine with the **go** keyword before it. It additionaly accepts a buffered channel and a WaitGroup. The scans are performed and when all scans are done the buffered channel is read and stored in the scan results.
Hit me with any question you have! It was just a quick proof of concept but can be refined further by running all hosts in paralel for example.

I did a very basic benchmark and could cut down the execution time of your code by a third. 

Cheers